### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+h5py==2.9.0
+Keras==2.0.6
+matplotlib==2.2.3
+nltk==3.4.5
+numpy==1.16.5
+scikit-learn==0.20.3
+tensorflow==1.1.0


### PR DESCRIPTION
I had some issues when trying to install, mainly because the readme doesn't list all the packages you need to train the model.

I have created a `requirements.txt` file that contains all the requirements I needed to call `train.py` without error.

Just note that the `.gitignore` lists `*.txt`, this should probably be changed so that changes to `requirements.txt` will be tracked.